### PR TITLE
Support config.json protocol/port in callback endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,8 @@ var fs = require('fs');
 
 //get config
 var config = require(process.cwd() + "/config.json");
+config.protocol = config.protocol || "http";
+config.port = config.port || "80";
 var appConfigJira = config.applications.jira;
 var appConfigBamboo = config.applications.bamboo;
 
@@ -32,7 +34,7 @@ var consumerJira =
         appConfigJira.oauth.consumer_key,
         appConfigJira.oauth.consumer_secret,
         "1.0",
-        "https://localhost/jira/callback/",
+        config.protocol + "://localhost:" + config.port + "/jira/callback/",
         "RSA-SHA1");
 
 
@@ -52,7 +54,7 @@ var consumerBamboo =
         appConfigBamboo.oauth.consumer_key,
         appConfigBamboo.oauth.consumer_secret,
         "1.0",
-        "https://localhost/bamboo/callback/",
+        config.protocol + "://localhost:" + config.port + "/bamboo/callback/",
         "RSA-SHA1");
 
 


### PR DESCRIPTION
The callback endpoints are hardcoded to HTTPS over port 80, which doesn't work if you are running the server over HTTP mode and with a different port (i.e. 8080 to avoid conflicts on port 80).

This allows the callback endpoints to function in all scenarios.